### PR TITLE
break out core functions from any script that is using them

### DIFF
--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -17,7 +17,8 @@ jobs:
         pip install -r requirements.txt
     - name: Run coverage tests
       run: |
-        coverage run -m unittest discover
+        coverage run -m unittest discover -v
+        coverage report
         coverage xml
     - name: Publish results to Codecov
       run: bash <(curl -s https://codecov.io/bash) -t "$CODECOV_TOKEN"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
 # TFMesh
 The built-for-purpose Terraform dependency manager.  TFMesh provides a simple and powerful CLI that allows you to get configuration version details and make updates that naturally integrates with current CI/CD processes.
 
+# Badges
+[![codecov](https://codecov.io/gh/Jsoconno/tfmesh/branch/master/graph/badge.svg?token=BW4GBBD7Y5)](https://codecov.io/gh/Jsoconno/tfmesh)
+![GitHub Workflow Status](https://img.shields.io/github/workflow/status/jsoconno/tfmesh/Publish%20to%20Codecov?label=tests)
+
+![GitHub commit activity](https://img.shields.io/github/commit-activity/y/jsoconno/tfmesh)
+![Lines of code](https://img.shields.io/tokei/lines/github/jsoconno/tfmesh)
+![GitHub issues](https://img.shields.io/github/v/tag/jsoconno/tfmesh)
+![GitHub issues](https://img.shields.io/github/issues/jsoconno/tfmesh)
+![GitHub closed issues](https://img.shields.io/github/issues-closed/jsoconno/tfmesh)
+![GitHub pull requests](https://img.shields.io/github/issues-pr/jsoconno/tfmesh)
+![GitHub closed pull requests](https://img.shields.io/github/issues-pr-closed/jsoconno/tfmesh)
+![GitHub contributors](https://img.shields.io/github/contributors/jsoconno/tfmesh)
+
 # Development Roadmap
 This project is under active development.  This section outlines the capability roadmap for TFMesh.  This will be taken down once the initial version of the tool is released into the wild.
 

--- a/README.md
+++ b/README.md
@@ -2,16 +2,19 @@
 The built-for-purpose Terraform dependency manager.  TFMesh provides a simple and powerful CLI that allows you to get configuration version details and make updates that naturally integrates with current CI/CD processes.
 
 # Badges
+![Latest tag](https://img.shields.io/github/v/tag/jsoconno/tfmesh)
+![Lines of code](https://img.shields.io/tokei/lines/github/jsoconno/tfmesh)
+
 [![codecov](https://codecov.io/gh/Jsoconno/tfmesh/branch/master/graph/badge.svg?token=BW4GBBD7Y5)](https://codecov.io/gh/Jsoconno/tfmesh)
 ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/jsoconno/tfmesh/Publish%20to%20Codecov?label=tests)
 
 ![GitHub commit activity](https://img.shields.io/github/commit-activity/y/jsoconno/tfmesh)
-![Lines of code](https://img.shields.io/tokei/lines/github/jsoconno/tfmesh)
-![GitHub issues](https://img.shields.io/github/v/tag/jsoconno/tfmesh)
-![GitHub issues](https://img.shields.io/github/issues/jsoconno/tfmesh)
-![GitHub closed issues](https://img.shields.io/github/issues-closed/jsoconno/tfmesh)
 ![GitHub pull requests](https://img.shields.io/github/issues-pr/jsoconno/tfmesh)
 ![GitHub closed pull requests](https://img.shields.io/github/issues-pr-closed/jsoconno/tfmesh)
+
+![GitHub issues](https://img.shields.io/github/issues/jsoconno/tfmesh)
+![GitHub closed issues](https://img.shields.io/github/issues-closed/jsoconno/tfmesh)
+
 ![GitHub contributors](https://img.shields.io/github/contributors/jsoconno/tfmesh)
 
 # Development Roadmap

--- a/main.py
+++ b/main.py
@@ -1,0 +1,38 @@
+from core import *
+
+files = get_terraform_files("terraform")
+dependencies = get_dependencies(files)
+
+table_headers = ["resource type", "name", "config version", "constraint", "latest version", "status"]
+table = []
+
+for dependency in dependencies:
+    current_version = dependency["version"]
+    valid_versions = get_valid_versions(
+        dependency["target"],
+        dependency["source"], 
+        dependency["version"], 
+        dependency["lower_constraint"], 
+        dependency["lower_constraint_operator"], 
+        dependency["upper_constraint"], 
+        dependency["upper_constraint_operator"],
+    )
+    latest_version = get_latest_version(valid_versions)
+
+    if current_version != latest_version and dependency["constraint"] == "":
+        status = f"{color('ok_blue')}pinned-outdated{color()}"
+    elif current_version != latest_version:
+        update_version(dependency["file_path"], dependency["code"], current_version, latest_version)
+        if compare_versions(get_semantic_version(current_version), ">", get_semantic_version(latest_version)):
+            status = f"{color('ok_cyan')}downgraded{color()}"
+        else:
+            status = f"{color('ok_green')}upgraded{color()}"
+    else:
+        status = f"up-to-date"
+        latest_version = None
+        
+    table.append([dependency["target"], dependency["name"], current_version, dependency["constraint"], latest_version, status])
+
+print('\n')
+print(tabulate(table, headers=table_headers, tablefmt='orgtbl'))
+print('\n')


### PR DESCRIPTION
previously all functions and the main script were in the same file.  this means that the whole script ran when tests were run against the functions.  this was an undesirable impact because it should not run and it was artificially ballooning the code coverage results.  also, it is just better to have your functions in their own place.

broke out these files.