### PR TITLE
split out the get_valid_versions function

### DIFF
--- a/core.py
+++ b/core.py
@@ -158,6 +158,9 @@ def get_github_user_and_repo(source):
     return data
 
 def get_available_versions(target, source):
+    """
+    Gets a list of available versions based on API calls to various endpoints.
+    """
     # Get required environment variables
     github_token = os.environ["PAT_TOKEN"]
 

--- a/core.py
+++ b/core.py
@@ -179,7 +179,7 @@ def get_available_versions(target, source):
 
     return available_versions
 
-def get_allowed_versions(available_versions, lower_constraint, lower_constraint_operator, upper_constraint, upper_constraint_operator):
+def get_allowed_versions(available_versions, lower_constraint="", lower_constraint_operator="", upper_constraint="", upper_constraint_operator=""):
     """
     Takes a list of available versions and considers constraints to get a list of allowed versions.
     """

--- a/core.py
+++ b/core.py
@@ -157,10 +157,7 @@ def get_github_user_and_repo(source):
 
     return data
 
-def get_valid_versions(target, source, version, lower_constraint, lower_constraint_operator, upper_constraint, upper_constraint_operator):
-    """
-    Takes in dependency version and constraint information to create a list of valid versions
-    """
+def get_available_versions(target, source):
     # Get required environment variables
     github_token = os.environ["PAT_TOKEN"]
 
@@ -175,8 +172,14 @@ def get_valid_versions(target, source, version, lower_constraint, lower_constrai
     elif target == "terraform":
         available_versions = get_terraform_versions()
     else:
-        print('what happened?')
+        available_versions = None
 
+    return available_versions
+
+def get_allowed_versions(available_versions, lower_constraint, lower_constraint_operator, upper_constraint, upper_constraint_operator):
+    """
+    Takes a list of available versions and considers constraints to get a list of allowed versions.
+    """
     if lower_constraint and not lower_constraint_operator:
         lower_constraint_operator = "="
 
@@ -237,12 +240,15 @@ def compare_versions(a, op, b):
 
     return result
 
-def get_latest_version(version_list):
+def get_latest_version(versions):
     """
     Provides the latest version based on a list of provided versions.
     """
-    version_list.sort(reverse=True)
-    latest_version = version_list[0]
+    if versions:
+        versions.sort(reverse=True)
+        latest_version = versions[0]
+    else:
+        latest_version = None
 
     return latest_version
 

--- a/main.py
+++ b/main.py
@@ -8,6 +8,10 @@ table = []
 
 for dependency in dependencies:
     available_versions = get_available_versions(dependency["target"], dependency["source"])
+    print(dependency["name"])
+    print('-----------')
+    print(dependency["lower_constraint"])
+    print(dependency["lower_constraint_operator"])
     allowed_versions = get_allowed_versions(
         available_versions,
         dependency["lower_constraint"],
@@ -15,9 +19,6 @@ for dependency in dependencies:
         dependency["upper_constraint"],
         dependency["upper_constraint_operator"],
     )
-    if dependency["name"] == "azurerm":
-        print(available_versions)
-        print(allowed_versions)
 
     # Versions
     current_version = dependency["version"]

--- a/main.py
+++ b/main.py
@@ -3,35 +3,41 @@ from core import *
 files = get_terraform_files("terraform")
 dependencies = get_dependencies(files)
 
-table_headers = ["resource type", "name", "config version", "constraint", "latest version", "status"]
+table_headers = ["resource type", "name", "current version", "latest version", "constraint", "latest allowed version", "status"]
 table = []
 
 for dependency in dependencies:
-    current_version = dependency["version"]
-    valid_versions = get_valid_versions(
-        dependency["target"],
-        dependency["source"], 
-        dependency["version"], 
-        dependency["lower_constraint"], 
-        dependency["lower_constraint_operator"], 
-        dependency["upper_constraint"], 
+    available_versions = get_available_versions(dependency["target"], dependency["source"])
+    allowed_versions = get_allowed_versions(
+        available_versions,
+        dependency["lower_constraint"],
+        dependency["lower_constraint_operator"],
+        dependency["upper_constraint"],
         dependency["upper_constraint_operator"],
     )
-    latest_version = get_latest_version(valid_versions)
+    if dependency["name"] == "azurerm":
+        print(available_versions)
+        print(allowed_versions)
 
-    if current_version != latest_version and dependency["constraint"] == "":
+    # Versions
+    current_version = dependency["version"]
+    latest_version = get_latest_version(available_versions)
+    latest_allowed_version = get_latest_version(allowed_versions)
+
+    if latest_allowed_version == None:
+        status = f"{color('warning')}no suitable version{color()}"
+    elif current_version != latest_allowed_version and dependency["constraint"] == "":
         status = f"{color('ok_blue')}pinned-outdated{color()}"
-    elif current_version != latest_version:
-        update_version(dependency["file_path"], dependency["code"], current_version, latest_version)
-        if compare_versions(get_semantic_version(current_version), ">", get_semantic_version(latest_version)):
+    elif current_version != latest_allowed_version:
+        update_version(dependency["file_path"], dependency["code"], current_version, latest_allowed_version)
+        if compare_versions(get_semantic_version(current_version), ">", get_semantic_version(latest_allowed_version)):
             status = f"{color('ok_cyan')}downgraded{color()}"
         else:
             status = f"{color('ok_green')}upgraded{color()}"
     else:
         status = f"up-to-date"
-        latest_version = None
         
-    table.append([dependency["target"], dependency["name"], current_version, dependency["constraint"], latest_version, status])
+    table.append([dependency["target"], dependency["name"], current_version, latest_version, dependency["constraint"], latest_allowed_version, status])
 
 print('\n')
 print(tabulate(table, headers=table_headers, tablefmt='orgtbl'))

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -4,7 +4,7 @@ terraform {
     required_providers {
         aws = {
             source = "hashicorp/aws"
-            version = "3.9.0" # ~>3.0
+            version = "3.0.0" # ~>3.0.0
         }
     }
     required_providers {

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -4,7 +4,7 @@ terraform {
     required_providers {
         aws = {
             source = "hashicorp/aws"
-            version = "3.0.0" # ~>3.0.0
+            version = "3.69.0" # 3.69.0
         }
     }
     required_providers {

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -8,9 +8,9 @@ terraform {
         }
     }
     required_providers {
-        aws = {
+        azurerm = {
             source = "hashicorp/azurerm"
-            version = "1.9.0" # >=1.9.0, <2.0.0
+            version = "1.9.0" # <2.0.0
         }
     }
 }

--- a/tests.py
+++ b/tests.py
@@ -50,7 +50,15 @@ class TestCore(unittest.TestCase):
         actual = get_latest_version(versions)
         expected = "v1.0.0"
 
-        self.assertEqual(actual, expected)
+    def test_get_latest_version_with_none_type(self):
+        """
+        Test that function returns the latest version.
+        """
+        versions = []
+
+        result = get_latest_version(versions)
+
+        self.assertIsNone(result)
 
     def test_version_tuple(self):
         """
@@ -74,6 +82,8 @@ class TestCore(unittest.TestCase):
         a = (1, 5, 0)
         b = (1, 5, 10)
         c = (1, 6)
+        d = (1,)
+
         result = (
             compare_versions(a, "=", a) and
             compare_versions(b, "", b) and
@@ -85,18 +95,46 @@ class TestCore(unittest.TestCase):
             compare_versions(b, "~>", a) and
             compare_versions(c, "~>", b)
         )
+
         self.assertTrue(result)
+
+    def test_compare_versions_with_none_types(self):
+        """
+        Test that null values passed to compare_versions result in a value of False.
+        """
+        a = (1, 5, 0)
+        b = (1, 5, 10)
+
+        result = (
+            compare_versions(a, "=", ()) and
+            compare_versions("", "=", b)
+        )
+
+        self.assertFalse(result)
+
+    def test_compare_versions_with_invalid_pessimistic_constraint(self):
+        """
+        Test that null values passed to compare_versions result in a value of False.
+        """
+        a = (1, 5, 10)
+        b = (1,)
+        with self.assertRaises(ValueError):
+            compare_versions(a, "~>", b)
 
     def test_get_allowed_versions_no_constraints(self):
         """
         Test passing no constraints.  It should return all available versions.
         """
         available_versions = ["v0.1.0","v0.1.1","v0.1.3","v0.1.4","v1.0.0","v1.1.2","v2.0.0","v2.0.1","v2.1.0"]
-        lower_constraint = ""
-        lower_constraint_operator = ""
-        upper_constraint = ""
-        upper_constraint_operator = ""
-        self.assertEqual(get_allowed_versions(available_versions, lower_constraint, lower_constraint_operator, upper_constraint, upper_constraint_operator), available_versions)
+        self.assertEqual(get_allowed_versions(available_versions), available_versions)
+
+    def test_get_allowed_versions_lower_constraint_no_operator(self):
+        """
+        Test passing a lower constraint with no operator.  Should result an equal operator (=).
+        """
+        available_versions = ["v0.1.0","v0.1.1","v0.1.3","v0.1.4","v1.0.0","v1.1.2","v2.0.0","v2.0.1","v2.1.0"]
+        lower_constraint = (0, 1, 3)
+        self.assertEqual(get_allowed_versions(available_versions, lower_constraint), ["v0.1.3"])
 
     def test_get_allowed_versions_one_constraint(self):
         """
@@ -105,9 +143,7 @@ class TestCore(unittest.TestCase):
         available_versions = ["v0.1.0","v0.1.1","v0.1.3","v0.1.4","v1.0.0","v1.1.2","v2.0.0","v2.0.1","v2.1.0"]
         lower_constraint = (2, 0, 0)
         lower_constraint_operator = ">"
-        upper_constraint = ""
-        upper_constraint_operator = ""
-        self.assertEqual(get_allowed_versions(available_versions, lower_constraint, lower_constraint_operator, upper_constraint, upper_constraint_operator), ["v2.0.1", "v2.1.0"])
+        self.assertEqual(get_allowed_versions(available_versions, lower_constraint, lower_constraint_operator), ["v2.0.1", "v2.1.0"])
 
     def test_get_allowed_versions_two_constraints(self):
         """

--- a/tests.py
+++ b/tests.py
@@ -73,6 +73,7 @@ class TestCore(unittest.TestCase):
         """
         a = (1, 5, 0)
         b = (1, 5, 10)
+        c = (1, 6)
         result = (
             compare_versions(a, "=", a) and
             compare_versions(b, "", b) and
@@ -81,7 +82,8 @@ class TestCore(unittest.TestCase):
             compare_versions(a, "<=", a) and
             compare_versions(b, ">", a) and
             compare_versions(b, "<=", b) and
-            compare_versions(b, "~>", a)
+            compare_versions(b, "~>", a) and
+            compare_versions(c, "~>", b)
         )
         self.assertTrue(result)
 
@@ -107,7 +109,7 @@ class TestCore(unittest.TestCase):
         upper_constraint_operator = ""
         self.assertEqual(get_allowed_versions(available_versions, lower_constraint, lower_constraint_operator, upper_constraint, upper_constraint_operator), ["v2.0.1", "v2.1.0"])
 
-    def test_get_allowed_versions_ge_lt(self):
+    def test_get_allowed_versions_two_constraints(self):
         """
         Test passing a lower and upper constraint.
         """

--- a/tests.py
+++ b/tests.py
@@ -81,7 +81,7 @@ class TestCore(unittest.TestCase):
         """
         a = (1, 5, 0)
         b = (1, 5, 10)
-        c = (1, 6)
+        c = (1, 4)
         d = (1,)
 
         result = (
@@ -93,7 +93,7 @@ class TestCore(unittest.TestCase):
             compare_versions(b, ">", a) and
             compare_versions(b, "<=", b) and
             compare_versions(b, "~>", a) and
-            compare_versions(c, "~>", b)
+            compare_versions(b, "~>", c)
         )
 
         self.assertTrue(result)

--- a/tests.py
+++ b/tests.py
@@ -71,7 +71,53 @@ class TestCore(unittest.TestCase):
         """
         Test that version comparisons work correctly.
         """
-        pass
+        a = (1, 5, 0)
+        b = (1, 5, 10)
+        result = (
+            compare_versions(a, "=", a) and
+            compare_versions(b, "", b) and
+            compare_versions(a, "!=", b) and
+            compare_versions(a, "<", b) and
+            compare_versions(a, "<=", a) and
+            compare_versions(b, ">", a) and
+            compare_versions(b, "<=", b) and
+            compare_versions(b, "~>", a)
+        )
+        self.assertTrue(result)
+
+    def test_get_allowed_versions_no_constraints(self):
+        """
+        Test passing no constraints.  It should return all available versions.
+        """
+        available_versions = ["v0.1.0","v0.1.1","v0.1.3","v0.1.4","v1.0.0","v1.1.2","v2.0.0","v2.0.1","v2.1.0"]
+        lower_constraint = ""
+        lower_constraint_operator = ""
+        upper_constraint = ""
+        upper_constraint_operator = ""
+        self.assertEqual(get_allowed_versions(available_versions, lower_constraint, lower_constraint_operator, upper_constraint, upper_constraint_operator), available_versions)
+
+    def test_get_allowed_versions_one_constraint(self):
+        """
+        Test passing a lower constraint.
+        """
+        available_versions = ["v0.1.0","v0.1.1","v0.1.3","v0.1.4","v1.0.0","v1.1.2","v2.0.0","v2.0.1","v2.1.0"]
+        lower_constraint = (2, 0, 0)
+        lower_constraint_operator = ">"
+        upper_constraint = ""
+        upper_constraint_operator = ""
+        self.assertEqual(get_allowed_versions(available_versions, lower_constraint, lower_constraint_operator, upper_constraint, upper_constraint_operator), ["v2.0.1", "v2.1.0"])
+
+    def test_get_allowed_versions_ge_lt(self):
+        """
+        Test passing a lower and upper constraint.
+        """
+        available_versions = ["v0.1.0","v0.1.1","v0.1.3","v0.1.4","v1.0.0","v1.1.2","v2.0.0","v2.0.1","v2.1.0"]
+        lower_constraint = (2, 0, 0)
+        lower_constraint_operator = ">="
+        upper_constraint = (2, 1, 0)
+        upper_constraint_operator = "<"
+        self.assertEqual(get_allowed_versions(available_versions, lower_constraint, lower_constraint_operator, upper_constraint, upper_constraint_operator), ["v2.0.0", "v2.0.1"])
+    
 
     def test_color(self):
         self.assertEqual(color("ok_blue"), "\033[94m")


### PR DESCRIPTION
broke out `get_valid_versions` into two functions:

* `get_available_versions`
* `get_allowed_versions`

added support for an edge case to `get_latest_version`

wrote tests for new functions for 100% coverage