### PR TITLE
Create status function

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,23 @@ Feature requirements:
 ## Raise a Pull Request
 * Raise a pull request in the Git repo where the Terraform code lives
 
+# Version Status
+TFMesh will evaluate versions in your configuration to determine the current version, latest available version, and latest allowed version.
+
+* `current version` - The current version set in the configuration.
+* `latest available version` - The latest available version available for Terraform or a given provider or module.
+* `latest allowed version` - The latest version that is allowed based on constraints in the configuration.
+
+The supported status are:
+
+* `(*) up-to-date` - The `current version` matches the `latest available version`.
+* `(->) upgraded to latest` - The `current version` was upgraded to the `latest available version`.
+* `(>)upgraded to allowed` - The `current version` was upgraded to the `latest allowed version` and is behind.
+* `(<-) downgraded to latest` - The `current version` was downgraded to the `latest available version`.
+* `(<) downgraded to allowed` - The `current version` was downgraded to the `latest allowed version` and is behind.
+* `(.) version pinned` - The `current version` is pinned and is behind.
+* `(x) no suitable version` - The was no available version that met the provided constraints.
+
 # TFMesh CLI
 The tfmesh cli provides a convenient way of working with version updates in Terraform that is suited for local development or CI/CD pipelines.
 

--- a/core.py
+++ b/core.py
@@ -285,8 +285,6 @@ def get_status(current_version, latest_available_version, latest_allowed_version
     if latest_allowed_version == None:
         latest_allowed_version = (0, 0, 0)
 
-    print(current_version, latest_available_version, latest_allowed_version)
-
     if latest_allowed_version is (0, 0, 0):
         status = f"{color('fail')}(x) no suitable version{color()}"
     elif compare_versions(current_version, "=", latest_available_version):

--- a/main.py
+++ b/main.py
@@ -8,10 +8,7 @@ table = []
 
 for dependency in dependencies:
     available_versions = get_available_versions(dependency["target"], dependency["source"])
-    print(dependency["name"])
-    print('-----------')
-    print(dependency["lower_constraint"])
-    print(dependency["lower_constraint_operator"])
+    # print(dependency["name"])
     allowed_versions = get_allowed_versions(
         available_versions,
         dependency["lower_constraint"],
@@ -22,24 +19,22 @@ for dependency in dependencies:
 
     # Versions
     current_version = dependency["version"]
-    latest_version = get_latest_version(available_versions)
+    latest_available_version = get_latest_version(available_versions)
     latest_allowed_version = get_latest_version(allowed_versions)
 
-    if latest_allowed_version == None:
-        status = f"{color('warning')}no suitable version{color()}"
-    elif current_version != latest_allowed_version and dependency["constraint"] == "":
-        status = f"{color('ok_blue')}pinned-outdated{color()}"
-    elif current_version != latest_allowed_version:
-        update_version(dependency["file_path"], dependency["code"], current_version, latest_allowed_version)
-        if compare_versions(get_semantic_version(current_version), ">", get_semantic_version(latest_allowed_version)):
-            status = f"{color('ok_cyan')}downgraded{color()}"
+    status = get_status(current_version, latest_available_version, latest_allowed_version)
+    what_if = True
+
+    if compare_versions(get_semantic_version(current_version), "!=", get_semantic_version(latest_allowed_version)):
+        if what_if:
+            pass
         else:
-            status = f"{color('ok_green')}upgraded{color()}"
-    else:
-        status = f"up-to-date"
+            update_version(dependency["file_path"], dependency["code"], current_version, latest_allowed_version)
         
-    table.append([dependency["target"], dependency["name"], current_version, latest_version, dependency["constraint"], latest_allowed_version, status])
+    table.append([dependency["target"], dependency["name"], current_version, latest_available_version, dependency["constraint"], latest_allowed_version, status])
 
 print('\n')
+if what_if:
+    print("This is a what if scenario.  No files were updated.")
 print(tabulate(table, headers=table_headers, tablefmt='orgtbl'))
 print('\n')

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -47,7 +47,7 @@ module "api_gateway" {
 }
 
 module "lambda" {
-  source = "github.com/jsoconno/terraform-module-aws-lambda?ref=v1.1.2" # >=1.0.0, <2.0.0
+  source = "github.com/jsoconno/terraform-module-aws-lambda?ref=v1.1.2" # >=1.0.0, <1.1.2
   #   source = "../terraform-module-aws-lambda"
 
   name = "test-lambda"
@@ -66,7 +66,7 @@ module "lambda" {
 
 module "consul" {
   source = "hashicorp/consul/aws"
-  version = "0.5.0" # >=0.2.0, <0.6.0
+  version = "0.4.0" # >=0.2.0, <0.6.0
 }
 
 module "conventions" {
@@ -85,7 +85,7 @@ module "consul" {
 }
 
 module "s3" {
-  source = "github.com/jsoconno/terraform-module-aws-s3?ref=v1.1.0" # ~>1.0
+  source = "github.com/jsoconno/terraform-module-aws-s3?ref=v2.1.0" # >=1.0.0
 # source = "../terraform-module-aws-s3"
 
   s3_access_iam_role_names = [

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -4,13 +4,13 @@ terraform {
     required_providers {
         aws = {
             source = "hashicorp/aws"
-            version = "3.69.0" # 3.69.0
+            version = "3.69.0" # =3.69.0
         }
     }
     required_providers {
         azurerm = {
             source = "hashicorp/azurerm"
-            version = "1.9.0" # <2.0.0
+            version = "1.9.0" # >=3.0.0, <2.0.0
         }
     }
 }

--- a/tests.py
+++ b/tests.py
@@ -155,10 +155,94 @@ class TestCore(unittest.TestCase):
         upper_constraint = (2, 1, 0)
         upper_constraint_operator = "<"
         self.assertEqual(get_allowed_versions(available_versions, lower_constraint, lower_constraint_operator, upper_constraint, upper_constraint_operator), ["v2.0.0", "v2.0.1"])
-    
 
     def test_color(self):
         self.assertEqual(color("ok_blue"), "\033[94m")
+
+    def test_get_status_up_to_date(self):
+        """
+        Test that the correct version change status is returned ((*) up-to-date).
+        """
+        current_version = "1.0.0"
+        latest_available_version = "1.0.0"
+        latest_allowed_version = "1.0.0"
+
+        status = get_status(current_version, latest_available_version, latest_allowed_version)
+
+        self.assertIn("(*) up-to-date", status)
+
+    def test_get_status_upgraded_to_latest(self):
+        """
+        Test that the correct version change status is returned ((->) upgraded to latest).
+        """
+        current_version = "1.0.0"
+        latest_available_version = "2.0.0"
+        latest_allowed_version = "2.0.0"
+
+        status = get_status(current_version, latest_available_version, latest_allowed_version)
+
+        self.assertIn("(->) upgraded to latest", status)
+
+    def test_get_status_upgraded_to_allowed(self):
+        """
+        Test that the correct version change status is returned ((>) upgraded to allowed).
+        """
+        current_version = "1.0.0"
+        latest_available_version = "3.0.0"
+        latest_allowed_version = "2.0.0"
+
+        status = get_status(current_version, latest_available_version, latest_allowed_version)
+
+        self.assertIn("(>) upgraded to allowed", status)
+
+    def test_get_status_downgraded_to_latest(self):
+        """
+        Test that the correct version change status is returned ((<-) downgraded to latest).
+        """
+        current_version = "3.0.0"
+        latest_available_version = "2.0.0"
+        latest_allowed_version = "2.0.0"
+
+        status = get_status(current_version, latest_available_version, latest_allowed_version)
+
+        self.assertIn("(<-) downgraded to latest", status)
+
+    def test_get_status_downgraded_to_allowed(self):
+        """
+        Test that the correct version change status is returned ((<) downgraded to allowed).
+        """
+        current_version = "3.0.0"
+        latest_available_version = "2.0.0"
+        latest_allowed_version = "1.0.0"
+
+        status = get_status(current_version, latest_available_version, latest_allowed_version)
+
+        self.assertIn("(<) downgraded to allowed", status)
+
+    def test_get_status_pinned(self):
+        """
+        Test that the correct version change status is returned ((.) version pinned).
+        """
+        current_version = "1.0.0"
+        latest_available_version = "2.0.0"
+        latest_allowed_version = "1.0.0"
+
+        status = get_status(current_version, latest_available_version, latest_allowed_version)
+
+        self.assertIn("(.) version pinned", status)
+
+    def test_get_status_no_suitable_version(self):
+        """
+        Test that the correct version change status is returned ((x) no suitable version).
+        """
+        current_version = "1.0.0"
+        latest_available_version = "1.0.0"
+        latest_allowed_version = None
+
+        status = get_status(current_version, latest_available_version, latest_allowed_version)
+
+        self.assertIn("(x) no suitable version", status)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Created a new function called `get_status` that takes in all of the version information and provides a status used for generating the final table.

An edge case was adjusted for in the `get_semantic_version` function and the `main.py` file was cleaned up to remove the old status print logic.

Finally, a crude dry run capability was added so that files are not constantly changed while testing.