### PR TITLE
Fix sorting and support pre-releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,12 @@ Feature requirements:
 ## Take Into Account User Constraints
 Feature requirements:
 * Allow special comments or configuration files to set constraints using Terraform's existing syntax.
-* Allow for global constrains including `major_bumps_allowed`, `minor_bumps_allowed`, and `patch_bumps_allowed`.
+* Allow for global constrains including:
+  * `max_bump` - values can be `major`, `minor`, or `patch`.
+  * `allow_prerelease` - default is True.
+  * `patch_versions_behind` - number
+  * `minor_versions_behind` - number
+  * `patch_versions_behind` - number
 * Create logic that can determine the minimum and maximium verions based on constraints.
 
 ## Compare Versions

--- a/core.py
+++ b/core.py
@@ -204,18 +204,6 @@ def get_allowed_versions(available_versions, lower_constraint="", lower_constrai
 
     # Apply logic to select the correct bump
 
-def version_tuple(version):
-    """
-    Turns a semantic version value into a tuple used for version comparison operations.
-    """
-    try:
-        version = tuple(map(int, (version.split("."))))
-    except:
-        # Added to fix a breaking change for pre-release versions.
-        version = None
-
-    return version
-
 def compare_versions(a, op, b):
     """
     Takes two tuples and compares them based on valid operations.

--- a/core.py
+++ b/core.py
@@ -281,17 +281,17 @@ def get_status(current_version, latest_available_version, latest_allowed_version
 
     if latest_allowed_version == None:
         status = f"{color('fail')}(x) no suitable version{color()}"
-    elif compare_versions(current_version, "=", latest_available_version):
+    elif compare_versions(current_version, "=", latest_available_version) and compare_versions(current_version, "=", latest_allowed_version):
         status = f"{color('ok_green')}(*) up-to-date{color()}"
-    elif compare_versions(current_version, "=", latest_allowed_version):
+    elif compare_versions(current_version, "!=", latest_available_version) and compare_versions(current_version, "=", latest_allowed_version):
         status = f"{color('warning')}(.) version pinned{color()}"
-    elif compare_versions(latest_available_version, "=", latest_allowed_version) and compare_versions(current_version, "<", latest_available_version):
+    elif compare_versions(current_version, "<", latest_available_version) and compare_versions(latest_available_version, "=", latest_allowed_version):
         status = f"{color('ok_green')}(->) upgraded to latest{color()}"
-    elif compare_versions(latest_available_version, ">", latest_allowed_version) and compare_versions(current_version, "<", latest_available_version):
+    elif compare_versions(current_version, "<", latest_available_version) and compare_versions(latest_available_version, ">", latest_allowed_version):
         status = f"{color('warning')}(>) upgraded to allowed{color()}"
     elif compare_versions(current_version, ">", latest_available_version) and compare_versions(latest_available_version, "=", latest_allowed_version):
         status = f"{color('ok_green')}(<-) downgraded to latest{color()}"
-    elif compare_versions(current_version, ">", latest_available_version) and compare_versions(latest_available_version, ">", latest_allowed_version):
+    elif compare_versions(current_version, ">", latest_allowed_version) and compare_versions(latest_available_version, ">", latest_allowed_version):
         status = f"{color('warning')}(<) downgraded to allowed{color()}"
     else:
         status = f"{color('fail')}(!) you found a bug{color()}"

--- a/core.py
+++ b/core.py
@@ -251,8 +251,7 @@ def get_latest_version(versions):
         versions = sort_versions(versions)
         latest_version = versions[0]
     else:
-        print('hit')
-        latest_version = ''
+        latest_version = None
 
     return latest_version
 

--- a/main.py
+++ b/main.py
@@ -8,7 +8,6 @@ table = []
 
 for dependency in dependencies:
     available_versions = get_available_versions(dependency["target"], dependency["source"])
-    # print(dependency["name"])
     allowed_versions = get_allowed_versions(
         available_versions,
         dependency["lower_constraint"],

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -4,7 +4,7 @@ terraform {
     required_providers {
         aws = {
             source = "hashicorp/aws"
-            version = "3.69.0" # =3.69.0
+            version = "3.90.0" # ~>3.0
         }
     }
     required_providers {

--- a/tests.py
+++ b/tests.py
@@ -60,21 +60,6 @@ class TestCore(unittest.TestCase):
 
         self.assertIsNone(result)
 
-    def test_version_tuple(self):
-        """
-        Test that version strings are properly converted to tuples.
-        """
-        good_version = "1.0.0"
-        bad_version = "v1.0.0"
-
-        good_actual = version_tuple(good_version)
-        good_expected = (1, 0, 0)
-
-        bad_actual = version_tuple(bad_version)
-
-        self.assertEqual(good_actual, good_expected)
-        self.assertIsNone(bad_actual)
-
     def test_compare_versions(self):
         """
         Test that version comparisons work correctly.

--- a/tests.py
+++ b/tests.py
@@ -229,6 +229,15 @@ class TestCore(unittest.TestCase):
 
         self.assertIn("(x) no suitable version", status)
 
+    def test_sort_versions(self):
+        """
+        Test that versions are properly sorted based on semantic version.
+        """
+        versions = ["1.0.0", "1.1.1", "1.10.0", "1.9.0", "2.0"]
+        result = sort_versions(versions)
+
+        self.assertEqual(result, ["2.0", "1.10.0", "1.9.0", "1.1.1", "1.0.0"])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests.py
+++ b/tests.py
@@ -37,9 +37,9 @@ class TestCore(unittest.TestCase):
         """
         Test that a list of versions can be returned from hashicorp for a given provider such as aws, gcp, or azurerm.
         """
-        actual = '3.70.0' in get_terraform_provider_versions(source="hashicorp/aws")
+        provider_versions = get_terraform_provider_versions(source="hashicorp/aws")
 
-        self.assertTrue(actual)
+        self.assertIn('3.70.0', provider_versions)
 
     def test_get_latest_version(self):
         """
@@ -118,7 +118,7 @@ class TestCore(unittest.TestCase):
         Test passing a lower constraint with no operator.  Should result an equal operator (=).
         """
         available_versions = ["v0.1.0","v0.1.1","v0.1.3","v0.1.4","v1.0.0","v1.1.2","v2.0.0","v2.0.1","v2.1.0"]
-        lower_constraint = (0, 1, 3)
+        lower_constraint = "0.1.3"
         self.assertEqual(get_allowed_versions(available_versions, lower_constraint), ["v0.1.3"])
 
     def test_get_allowed_versions_one_constraint(self):
@@ -126,7 +126,7 @@ class TestCore(unittest.TestCase):
         Test passing a lower constraint.
         """
         available_versions = ["v0.1.0","v0.1.1","v0.1.3","v0.1.4","v1.0.0","v1.1.2","v2.0.0","v2.0.1","v2.1.0"]
-        lower_constraint = (2, 0, 0)
+        lower_constraint = "v2.0.0"
         lower_constraint_operator = ">"
         self.assertEqual(get_allowed_versions(available_versions, lower_constraint, lower_constraint_operator), ["v2.0.1", "v2.1.0"])
 
@@ -135,10 +135,11 @@ class TestCore(unittest.TestCase):
         Test passing a lower and upper constraint.
         """
         available_versions = ["v0.1.0","v0.1.1","v0.1.3","v0.1.4","v1.0.0","v1.1.2","v2.0.0","v2.0.1","v2.1.0"]
-        lower_constraint = (2, 0, 0)
+        lower_constraint = "2.0.0"
         lower_constraint_operator = ">="
-        upper_constraint = (2, 1, 0)
+        upper_constraint = "2.1.0"
         upper_constraint_operator = "<"
+
         self.assertEqual(get_allowed_versions(available_versions, lower_constraint, lower_constraint_operator, upper_constraint, upper_constraint_operator), ["v2.0.0", "v2.0.1"])
 
     def test_color(self):


### PR DESCRIPTION
This pull request adds support for pre-releases and fixes a bug with sorting where a version like `1.9.0` would be considered greater than `1.69.0` based on basic string sorting using `.sort()`.  These updates streamlined some of the code making it so there is no longer a need to call certain functions just to jump between a text and tuple-based semantic version.

* Refactored code to eliminate the need for the `version_tuple` function and removed the test.
* Fixed a bug in the `get_status` function
* Added a new `sort_versions` function fixing a bug with version sorting
* Improved the `get_semantic_version` function to have a better regular expression that supports pre-release numbers
* Updated existing tests where refactoring changed results and wrote a test for the `get_status` function