### PR TITLE
Auto-dependency pipeline fix

### DIFF
--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -43,6 +43,7 @@ jobs:
           committer: GitHub <noreply@github.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           branch: module-version-updates
+          base: ${{ github.head_ref }}
           delete-branch: true
           title: 'Terraform module version updates'
           labels: |

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -14,7 +14,7 @@ on:
     - cron:  '0 */24 * * *'
 
 jobs:
-  terradepend:
+  tfmesh:
     runs-on: ubuntu-latest
     name: "Automated Module Version Updates"
     steps:
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
-      - name: Update Terraform Dependencies
+      - name: Run Python Script
         id: tfmesh
         run: |
           pip install requests

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -71,7 +71,7 @@ module "consul" {
 
 module "conventions" {
   source  = "Jsoconno/conventions/azure"
-  version = "6.0.0"
+  version = "5.0.0"
   # insert the 1 required variable here
 }
 


### PR DESCRIPTION
Bug fix to make the pipeline work.  Solution was to set the `base` arguments to `base: ${{ github.head_ref }}`.  Seems like a bug in the action.