### PR TITLE
Variable support and API failure handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ The following options are supported:
 * `--config-file` - the name of the configuration file (defaults to ".tfmesh.yaml")
 * `--terraform-folder` - the name of the folder where Terraform files are located (defaults to the current directory).
 * `--terraform-file-pattern` - the pattern for matching Terraform files within the directory (defaults to *.tf).
+* `--var` - one or more variables to be added to the configuration file.
 * `--force` - allows for non-interactive reset of the configuration file for automation purposes.
 
 Example:
@@ -154,6 +155,7 @@ The following options are supported:
 * `--allowed` - returns only allowed versions when used in conjunction with the versions attribute.
 * `--exclude-prerelease` - returns all non-prerelease versions when used in conjunction with the versions attribute.
 * `--top` - returns the top n number of results when used in conjunction with the versions attribute.
+* `--var` - one or more variables to set on the command line.
 
 Example:
 ```cmd
@@ -178,6 +180,7 @@ The following options are supported:
 * `--exclude-prerelease` - ensures the set version is not a pre-release.
 * `--what-if` - allows for a dry run to see what would happen before making changes.
 * `--ignore-constraints` - allows the version to be set to a valid version that does not meet the defined constraint.
+* `--var` - one or more variables to set on the command line.
 * `--force` - allows the version to be set to any value without validation.
 
 Example:
@@ -198,6 +201,7 @@ The following options are supported:
 * `--ignore-constraints` - allows the version to be set to a valid version that does not meet the defined constraint.
 * `--no-color` - removes terminal color formatting.
 * `--verbose` - returns all resources as part of the plan including those with no version changes.
+* `--var` - one or more variables to set on the command line.
 
 Example:
 ```cmd
@@ -218,6 +222,7 @@ The following options are supported:
 * `--no-color` - removes terminal color formatting.
 * `--verbose` - returns all resources as part of the apply including those with no version changes.
 * `--auto-approve` - approves upgrades without prompting for user input.
+* `--var` - one or more variables to set on the command line.
 
 Example:
 ```cmd

--- a/README.md
+++ b/README.md
@@ -286,11 +286,16 @@ Plan: 1 to upgrade, 1 to downgrade
 ```
 # Setting variables
 
-There are three ways to add a variable to Terraform Mesh.  The following list provides the options in order of highest to lowest precedence:
+Variables allow users to pass data to Terraform Mesh, primarily for authenticating with private repositories.  If the same variable is assigned multiple values, Terraform Mesh uses the last value it finds, overriding any previous values.
+
+Terraform Mesh supports three methods for setting variables:
+Terraform Mesh loads variables in the following order, with later sources taking precedence over earlier ones:
 
 * **The command line** - variables can be passed on the command line for all commands using the `--var` flag.  All variables must be in the format `--var="name=value"`.  With this method, variables need to be passed every time they are required for a command.
 * **The configuration file** - variables can also be saved in the configuration file using the same `--var` syntax above.  This allows variables to be persistent across all commands making things simpler when working locally.  Be warned that secret values will be in plain text in the configuration file.  It is recommended to make sure to add this file to `.gitignore`.
 * **The terminal** - any variable can be set in the terminal as an environment variable.  Simple append `TFMESH_` to any variable you want to be able to reference in your session.  For example `export TFMESH_GITHUB_PAT=somethingprivate`.
+
+Terraform Mesh will always load all variable sources in with earlier sources taking precedence over later ones:
 
 # Handling errors
 

--- a/README.md
+++ b/README.md
@@ -289,13 +289,23 @@ Plan: 1 to upgrade, 1 to downgrade
 Variables allow users to pass data to Terraform Mesh, primarily for authenticating with private repositories.  If the same variable is assigned multiple values, Terraform Mesh uses the last value it finds, overriding any previous values.
 
 Terraform Mesh supports three methods for setting variables:
-Terraform Mesh loads variables in the following order, with later sources taking precedence over earlier ones:
 
-* **The command line** - variables can be passed on the command line for all commands using the `--var` flag.  All variables must be in the format `--var="name=value"`.  With this method, variables need to be passed every time they are required for a command.
-* **The configuration file** - variables can also be saved in the configuration file using the same `--var` syntax above.  This allows variables to be persistent across all commands making things simpler when working locally.  Be warned that secret values will be in plain text in the configuration file.  It is recommended to make sure to add this file to `.gitignore`.
-* **The terminal** - any variable can be set in the terminal as an environment variable.  Simple append `TFMESH_` to any variable you want to be able to reference in your session.  For example `export TFMESH_GITHUB_PAT=somethingprivate`.
+* **The command line** - variables can be passed on the command line for all commands using the `--var` flag.  All variables must be in the format `--var="name=value"`.  With this method, variables need to be passed every time they are required for a command.  In other words, they are not persisted.
+* **The configuration file** - variables can also be saved in the configuration file using the same `--var` syntax above in combination with the `init` command.  This allows variables to be persistent across all commands making things simpler when working locally.  Be warned that secret values will be in plain text in the configuration file.  It is recommended to make sure to add this file to `.gitignore`.
+* **The terminal** - any variable can be set in the terminal as an environment variable.  Simply append `TFMESH_` to any variable you want to be able to reference in your session.  For example `export TFMESH_GITHUB_PAT=somethingprivate`.
 
-Terraform Mesh will always load all variable sources in with earlier sources taking precedence over later ones:
+Terraform Mesh will always load all variable sources in with the earlier sources in this list taking precedence over later ones.  Valid variable names only use alphanumerics and underscores.  Any non-alphanumeric characters will be removed and dashes converted to underscores when the variable is processed.
+
+For example, setting a variable like `tfmesh get module some_module versions -var="som3-v@r=this"` would be converted on the backend to `TFMESH_SOM_VR=this` because the `3` at `@` symbol would be stripped and the dash (`-`) converted to an underscore (`_`).
+
+# Authentication
+
+The primary way that Terraform Mesh interacts with other private git repositories is through the user of personal access tokens (PAT).  For each supported private provider or module source a PAT must be provided.
+
+Supported private git repositories:
+* GitHub - use the `github_token` variable or `TFMESH_GITHUB_TOKEN` environment variable.
+
+To get versions from a private repo, the appropriate token variable must be set.  This can be done on the command line at runtime using the `--var` flag in combination with the `get`, `plan`, and `apply` commands.  This is the best option if you are targeting multiple private repos in your configuration.  Variables can also be set in your configuration using the `--var` flag in combination with `tfmesh init`.  The final way is to directly set the environment variable in the terminal using `export TFMESH_SOME_TOKEN`.
 
 # Handling errors
 

--- a/README.md
+++ b/README.md
@@ -276,10 +276,10 @@ terraform {
 -/. required_version = "1.1.4" # =1.0.0 // downgrade to latest allowed = 1.0.0
 
 
-        aws = {
-            source = "hashicorp/aws"
-        +/* version = "3.72.0" # ~>3.0 // upgrade to latest available = 3.73.0
-        }
+aws = {
+    source = "hashicorp/aws"
++/* version = "3.72.0" # ~>3.0 // upgrade to latest available = 3.73.0
+}
 
 
 Plan: 1 to upgrade, 1 to downgrade

--- a/README.md
+++ b/README.md
@@ -284,3 +284,30 @@ aws = {
 
 Plan: 1 to upgrade, 1 to downgrade
 ```
+# Setting variables
+
+There are three ways to add a variable to Terraform Mesh.  The following list provides the options in order of highest to lowest precedence:
+
+* **The command line** - variables can be passed on the command line for all commands using the `--var` flag.  All variables must be in the format `--var="name=value"`.  With this method, variables need to be passed every time they are required for a command.
+* **The configuration file** - variables can also be saved in the configuration file using the same `--var` syntax above.  This allows variables to be persistent across all commands making things simpler when working locally.  Be warned that secret values will be in plain text in the configuration file.  It is recommended to make sure to add this file to `.gitignore`.
+* **The terminal** - any variable can be set in the terminal as an environment variable.  Simple append `TFMESH_` to any variable you want to be able to reference in your session.  For example `export TFMESH_GITHUB_PAT=somethingprivate`.
+
+# Handling errors
+
+Support was added to allow users to see when a resource that is located in a private repo is not accessible for some reason.
+
+Below are the common errors and what they most likely mean.
+
+**404 Not Found** - The authentication token (PAT) for the target repository is not set.  This can be set on the command line or added to the configuration file using the `--var` flag.  
+
+Note that if you add a token to the configuration file it will be in plain text.  Please protect this information and be sure to add the file to your `.gitignore`.  
+
+Examples:
+```cmd
+tfmesh init --var="github_pat=somethingprivate"
+```
+```cmd
+tfmesh plan --var="github_pat=somethingprivate"
+```
+
+**401 Unauthorized** - An authentication token (PAT) for the target repository was set, but is either invalid or expired.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,11 +1,11 @@
 module "consul" {
   source = "hashicorp/consul/aws"
-  version = "0.4.0" # ~>0.5.0
+  version = "0.5.0" # ~>0.5.0
 }
 
 module "conventions" {
   source  = "Jsoconno/conventions/azure"
-  version = "0.5.0" # ~>0.4
+  version = "0.5.3" # ~>0.4
   # insert the 1 required variable here
 }
 

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -8,7 +8,7 @@ terraform {
         }
         azurerm = {
             source = "hashicorp/azurerm"
-            version = "2.93.1" # >=2.0.0
+            version = "2.93.1" # >1.1.0
         }
     }
 }

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-    required_version = "1.1.1" # >=1.1.1
+    required_version = "1.1.4" # >=1.1.1
 
     required_providers {
         aws = {
@@ -8,7 +8,7 @@ terraform {
         }
         azurerm = {
             source = "hashicorp/azurerm"
-            version = "2.93.0" # >=2.0.0
+            version = "2.93.1" # >=2.0.0
         }
     }
 }

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -28,16 +28,16 @@ class TestCore(unittest.TestCase):
         """
         Test that a list of tags can be returned from a github repo without headers.
         """
-        actual = isinstance(get_github_module_versions(user='jsoconno', repo='tfmesh'), list)
-        expected = isinstance([], list)
+        result = get_github_module_versions(user='jsoconno', repo='tfmesh')
 
-        self.assertEqual(actual, expected)
+        self.assertGreater(len(result["versions"]), 0)
+        self.assertEqual(result["status_code"], 200)
 
     def test_get_terraform_provider_versions(self):
         """
         Test that a list of versions can be returned from hashicorp for a given provider such as aws, gcp, or azurerm.
         """
-        provider_versions = get_terraform_provider_versions(source="hashicorp/aws")
+        provider_versions = get_terraform_provider_versions(source="hashicorp/aws")["versions"]
 
         self.assertIn('3.70.0', provider_versions)
 
@@ -160,8 +160,8 @@ class TestCore(unittest.TestCase):
         """
         Test that the number of available versions is less when pre-releases are excluded.
         """
-        result_with_pre_releases = get_available_versions("terraform", exclude_pre_release=False)
-        result_without_pre_releases = get_available_versions("terraform", exclude_pre_release=True)
+        result_with_pre_releases = get_available_versions("terraform", exclude_pre_release=False)["versions"]
+        result_without_pre_releases = get_available_versions("terraform", exclude_pre_release=True)["versions"]
 
         self.assertGreater(result_with_pre_releases, result_without_pre_releases)
         self.assertIn("0.12.0-alpha3", result_with_pre_releases)

--- a/tfmesh/__init__.py
+++ b/tfmesh/__init__.py
@@ -18,23 +18,24 @@ def cli(ctx):
 @click.option("--config-file", default=".tfmesh.yaml")
 @click.option("--terraform-folder", default="")
 @click.option("--terraform-file-pattern", default="*.tf")
+@click.option("--var", multiple=True)
 @click.option("--force", is_flag=True)
-def init(config_file, terraform_folder, terraform_file_pattern, force):
+def init(config_file, terraform_folder, terraform_file_pattern, var, force):
     """
     Initializes a file with details about the configuration.
     """
     config_file = Path(config_file)
     if config_file.is_file():
         if force:
-            set_config(config_file, terraform_folder, terraform_file_pattern)
+            set_config(config_file, terraform_folder, terraform_file_pattern, var)
             click.echo("The configuration was updated.")
         if click.confirm("A configuration file already exists.  Would you like to update it?"):
-            set_config(config_file, terraform_folder, terraform_file_pattern)
+            set_config(config_file, terraform_folder, terraform_file_pattern, var)
             click.echo("The configuration was updated.")
         else:
             click.echo("The configuration was not changed.")
     else:
-        set_config(config_file, terraform_folder, terraform_file_pattern)
+        set_config(config_file, terraform_folder, terraform_file_pattern, var)
         click.echo("The configuration was created.")
 
 @cli.group("get")
@@ -56,11 +57,13 @@ def set():
 @click.option("--allowed", is_flag=True)
 @click.option("--exclude-prerelease", is_flag=True)
 @click.option("--top", type=int, default=None)
+@click.option("--var", multiple=True)
 @click.pass_obj
-def terraform(config, attribute, allowed, exclude_prerelease, top):
+def terraform(config, attribute, allowed, exclude_prerelease, top, var):
     """
     Gets a given attribute for the Terraform executable.
     """
+    set_environment_variables(var)
     result = get_dependency_attribute(
         terraform_files=config["terraform_files"],
         patterns={
@@ -95,11 +98,13 @@ def providers(config):
 @click.option("--allowed", is_flag=True)
 @click.option("--exclude-prerelease", is_flag=True)
 @click.option("--top", type=int, default=None)
+@click.option("--var", multiple=True)
 @click.pass_obj
-def provider(config, name, attribute, allowed, exclude_prerelease, top):
+def provider(config, name, attribute, allowed, exclude_prerelease, top, var):
     """
     Gets a given attribute for provider.
     """
+    set_environment_variables(var)
     result = get_dependency_attribute(
         terraform_files=config["terraform_files"],
         patterns={
@@ -137,11 +142,13 @@ def modules(config):
 @click.option("--allowed", is_flag=True)
 @click.option("--exclude-prerelease", is_flag=True)
 @click.option("--top", type=int, default=None)
+@click.option("--var", multiple=True)
 @click.pass_obj
-def module(config, name, attribute, allowed, exclude_prerelease, top):
+def module(config, name, attribute, allowed, exclude_prerelease, top, var):
     """
     Gets a given attribute for module.
     """
+    set_environment_variables(var)
     result = get_dependency_attribute(
         terraform_files=config["terraform_files"],
         patterns={
@@ -167,10 +174,11 @@ def module(config, name, attribute, allowed, exclude_prerelease, top):
 @click.option("--ignore-constraints", is_flag=True)
 @click.option("--force", is_flag=True)
 @click.pass_obj
-def terraform(config, attribute, value, exclude_prerelease, what_if, ignore_constraints, force):
+def terraform(config, attribute, value, exclude_prerelease, what_if, ignore_constraints, var, force):
     """
     Sets the version or constraint for the Terraform executable.
     """
+    set_environment_variables(var)
     result = set_dependency_attribute(
         terraform_files=config["terraform_files"],
         patterns={
@@ -194,12 +202,14 @@ def terraform(config, attribute, value, exclude_prerelease, what_if, ignore_cons
 @click.option("--exclude-prerelease", is_flag=True)
 @click.option("--what-if", is_flag=True)
 @click.option("--ignore-constraints", is_flag=True)
+@click.option("--var", multiple=True)
 @click.option("--force", is_flag=True)
 @click.pass_obj
-def provider(config, name, attribute, value, exclude_prerelease, what_if, ignore_constraints, force):
+def provider(config, name, attribute, value, exclude_prerelease, what_if, ignore_constraints, var, force):
     """
     Sets the version or constraint for a given provider.
     """
+    set_environment_variables(var)
     result = set_dependency_attribute(
         terraform_files=config["terraform_files"],
         patterns={
@@ -223,12 +233,14 @@ def provider(config, name, attribute, value, exclude_prerelease, what_if, ignore
 @click.option("--exclude-prerelease", is_flag=True)
 @click.option("--what-if", is_flag=True)
 @click.option("--ignore-constraints", is_flag=True)
+@click.option("--var", multiple=True)
 @click.option("--force", is_flag=True)
 @click.pass_obj
-def module(config, name, attribute, value, exclude_prerelease, what_if, ignore_constraints, force):
+def module(config, name, attribute, value, exclude_prerelease, what_if, ignore_constraints, var, force):
     """
     Sets the version or constraint for a given module.
     """
+    set_environment_variables(var)
     result = set_dependency_attribute(
         terraform_files=config["terraform_files"],
         patterns={
@@ -254,11 +266,13 @@ def module(config, name, attribute, value, exclude_prerelease, what_if, ignore_c
 @click.option("--ignore-constraints", is_flag=True)
 @click.option("--no-color", is_flag=True)
 @click.option("--verbose", is_flag=True)
+@click.option("--var", multiple=True)
 @click.pass_obj
-def plan(config, target, exclude_prerelease, ignore_constraints, no_color, verbose):
+def plan(config, target, exclude_prerelease, ignore_constraints, no_color, verbose, var):
     """
     Plans what version changes will be made to the configuration.
     """
+    set_environment_variables(var)
     run_plan_apply(
         terraform_files=config["terraform_files"],
         patterns = {
@@ -283,11 +297,13 @@ def plan(config, target, exclude_prerelease, ignore_constraints, no_color, verbo
 @click.option("--no-color", is_flag=True)
 @click.option("--verbose", is_flag=True)
 @click.option("--auto-approve", is_flag=True)
+@click.option("--var", multiple=True)
 @click.pass_obj
-def apply(config, target, exclude_prerelease, ignore_constraints, no_color, verbose, auto_approve):
+def apply(config, target, exclude_prerelease, ignore_constraints, no_color, verbose, auto_approve, var):
     """
     Applies configuration version changes.
     """
+    set_environment_variables(var)
     run_plan_apply(
         terraform_files=config["terraform_files"],
         patterns = {

--- a/tfmesh/core.py
+++ b/tfmesh/core.py
@@ -178,6 +178,8 @@ def set_dependency_attribute(terraform_files, patterns, resource_type, name, att
 
     if current_value == new_value:
         result = pretty_print(f'The {attribute} is already set to "{new_value}".')
+    elif what_if:
+        result = pretty_print(f'The {attribute} was would have changed from "{current_value}" to "{new_value}".')
     elif attribute == "version" and request["status_code"] != 200 and force:
         update_version(
             filepath=dependencies[resource_type][name]["filepath"],

--- a/tfmesh/core.py
+++ b/tfmesh/core.py
@@ -326,7 +326,7 @@ def get_available_versions(target, source=None, exclude_pre_release=False):
     """
     # Get required environment variables
     try:
-        github_token = os.environ["TFMESH_GITHUB_PAT"]
+        github_token = os.environ["TFMESH_GITHUB_TOKEN"]
     except:
         github_token = ""
 

--- a/tfmesh/core.py
+++ b/tfmesh/core.py
@@ -342,7 +342,8 @@ def get_available_versions(target, source=None, exclude_pre_release=False):
         available_versions = None
 
     if exclude_pre_release:
-        available_versions = [version for version in available_versions if len(get_semantic_version(version)) < 4]
+        versions = available_versions["versions"]
+        available_versions["versions"] = [version for version in versions if len(get_semantic_version(version)) < 4]
 
     return available_versions
 

--- a/tfmesh/core.py
+++ b/tfmesh/core.py
@@ -789,6 +789,7 @@ def set_environment_variables(var, config_file=".tfmesh.yaml"):
     command_line_variables = {}
     for v in var:
         name, value = re.findall(r'(\S*) *= *(\S*)', v)[0]
+        name = name.replace("-", "_")
         name = re.sub(r'[^a-zA-Z0-9_]', "", name)
         command_line_variables[name] = value
 

--- a/tfmesh/core.py
+++ b/tfmesh/core.py
@@ -50,12 +50,21 @@ def get_terraform_files(terraform_folder=None, file_pattern='*.tf'):
     
     return file_list
 
-def set_config(config_file=".tfmesh.yaml", terraform_folder="", terraform_file_pattern="*.tf"):
+def set_config(config_file=".tfmesh.yaml", terraform_folder="", terraform_file_pattern="*.tf", var=None):
+    """
+    """
+    variables = {}
+    for v in var:
+        name, value = re.findall(r'(\S*) *= *(\S*)', v)[0]
+        name = re.sub(r'[^a-zA-Z0-9_]', "", name)
+        variables[name] = value
+
     with open(config_file, 'w') as config_file:
         config = {
             "terraform_folder": terraform_folder,
             "terraform_file_pattern": terraform_file_pattern,
-            "terraform_files": get_terraform_files(terraform_folder, terraform_file_pattern)
+            "terraform_files": get_terraform_files(terraform_folder, terraform_file_pattern),
+            "variables": variables
         }
         yaml.dump(config, config_file, default_flow_style=False)
 
@@ -107,13 +116,12 @@ def get_dependency_attribute(terraform_files, patterns, resource_type, name, att
         patterns=patterns
     )
     if attribute == "versions":
-        available_versions = sort_versions(
-            get_available_versions(
-                target=dependencies[resource_type][name]["target"],
-                source=dependencies[resource_type][name]["source"],
-                exclude_pre_release=exclude_prerelease
-            )
+        request = get_available_versions(
+            target=dependencies[resource_type][name]["target"],
+            source=dependencies[resource_type][name]["source"],
+            exclude_pre_release=exclude_prerelease
         )
+        available_versions = sort_versions(request["versions"])
         allowed_versions = sort_versions(
             get_allowed_versions(
                 available_versions,
@@ -123,7 +131,9 @@ def get_dependency_attribute(terraform_files, patterns, resource_type, name, att
                 dependencies[resource_type][name]["upper_constraint_operator"],
             )
         )
-        if allowed:
+        if request["status_code"] != 200:
+            result = pretty_print(f'The API call to return versions for {name} failed.')
+        elif allowed:
             result = pretty_print(allowed_versions, top=top)
         else:
             result = pretty_print(available_versions, top=top)
@@ -141,13 +151,12 @@ def set_dependency_attribute(terraform_files, patterns, resource_type, name, att
         patterns=patterns
     )
     if attribute == "version":
-        available_versions = sort_versions(
-            get_available_versions(
-                target=dependencies[resource_type][name]["target"],
-                source=dependencies[resource_type][name]["source"],
-                exclude_pre_release=exclude_prerelease
-            )
+        request = get_available_versions(
+            target=dependencies[resource_type][name]["target"],
+            source=dependencies[resource_type][name]["source"],
+            exclude_pre_release=exclude_prerelease
         )
+        available_versions = sort_versions(request["versions"])
         allowed_versions = sort_versions(
             get_allowed_versions(
                 available_versions,
@@ -169,6 +178,16 @@ def set_dependency_attribute(terraform_files, patterns, resource_type, name, att
 
     if current_value == new_value:
         result = pretty_print(f'The {attribute} is already set to "{new_value}".')
+    elif attribute == "version" and request["status_code"] != 200 and force:
+        update_version(
+            filepath=dependencies[resource_type][name]["filepath"],
+            code=dependencies[resource_type][name]["code"],
+            attribute=attribute,
+            value=value
+        )
+        result = pretty_print(f'The {attribute} was changed from "{current_value}" to "{new_value}" without validation.')
+    elif attribute == "version" and request["status_code"] != 200:
+        result = pretty_print(f'The API call to return versions for {name} failed.')
     elif force or new_value in versions or attribute == "constraint":
         update_version(
             filepath=dependencies[resource_type][name]["filepath"],
@@ -224,11 +243,20 @@ def get_github_module_versions(user, repo, token=None):
     else:
         response = requests.get(f"https://api.github.com/repos/{user}/{repo}/tags")
 
-    tag_data = json.loads(response.text)
+    if response.status_code == 200:
+        tag_data = json.loads(response.text)
+        versions = [x["name"] for x in tag_data]
+    else:
+        # error = f'{response.status_code} {response.reason}'
+        versions = []
 
-    tag_list = [x["name"] for x in tag_data]
+    result = {
+        "status_code": response.status_code,
+        "reason": response.reason,
+        "versions": versions
+    }
 
-    return tag_list
+    return result
 
 def get_terraform_module_versions(source):
     """
@@ -236,8 +264,14 @@ def get_terraform_module_versions(source):
     """
     response = requests.get(f"https://registry.terraform.io/v1/modules/{source}")
     data = json.loads(response.text)
+
+    result = {
+        "status_code": response.status_code,
+        "reason": response.reason,
+        "versions": data["versions"]
+    }
     
-    return data["versions"]
+    return result
 
 def get_terraform_provider_versions(source):
     """
@@ -245,8 +279,14 @@ def get_terraform_provider_versions(source):
     """
     response = requests.get(f"https://registry.terraform.io/v1/providers/{source}")
     data = json.loads(response.text)
+
+    result = {
+        "status_code": response.status_code,
+        "reason": response.reason,
+        "versions": data["versions"]
+    }
     
-    return data["versions"]
+    return result
 
 def get_terraform_versions():
     """
@@ -257,7 +297,13 @@ def get_terraform_versions():
     pattern = r'terraform_((\d+)\.*(\d+)*\.*(\d+)*-?([\S]*))</a>'
     versions = re.findall(pattern, response.text)
 
-    return [version[0] for version in versions]
+    result = {
+        "status_code": response.status_code,
+        "reason": response.reason,
+        "versions": [version[0] for version in versions]
+    }
+
+    return result
 
 def get_github_user_and_repo(source):
     """
@@ -278,9 +324,9 @@ def get_available_versions(target, source=None, exclude_pre_release=False):
     """
     # Get required environment variables
     try:
-        github_token = os.environ["PAT_TOKEN"]
+        github_token = os.environ["TFMESH_GITHUB_PAT"]
     except:
-        pass
+        github_token = ""
 
     # Pull available versions
     if target == "modules" and "github" in source:
@@ -595,14 +641,17 @@ def run_plan_apply(terraform_files, patterns, target=[], apply=False, verbose=Fa
         "no change": 0
     }
 
+    failures = 0
+
     # iterate through resources to get available and allowed versions
     for resource_type, resources in resources.items():
         for resource, attributes in resources.items():
-            available_versions = get_available_versions(
+            request = get_available_versions(
                 target=attributes["target"],
                 source=attributes["source"],
                 exclude_pre_release=exclude_prerelease
             )
+            available_versions = request["versions"]
             allowed_versions = get_allowed_versions(
                 available_versions,
                 attributes["lower_constraint"],
@@ -652,16 +701,21 @@ def run_plan_apply(terraform_files, patterns, target=[], apply=False, verbose=Fa
                 else:
                     pass
             else:
+                if request["status_code"] != 200:
+                    failures += 1
                 if verbose:
                     plan["no change"] += 1
-                    # iterate through code
-                    for line in code:
-                        if current_version in line:
-                            print(f'{prefix_status(status["symbol"], line, status["color"])}{"" if no_color else get_color(status["color"])} // {status["action"]}{"" if no_color else get_color()}')
-                        else:
-                            print(line)
+                    if request["status_code"] != 200:
+                        print(f'{get_color("fail")}~/x {get_color()}The API call to return versions for {attributes["target"]} "{attributes["name"]}" failed.{get_color("fail")} // {request["status_code"]} {request["reason"]}.{get_color()}\n\n')
+                    else:
+                        # iterate through code
+                        for line in code:
+                            if current_version in line:
+                                print(f'{prefix_status(status["symbol"], line, status["color"])}{"" if no_color else get_color(status["color"])} // {status["action"]} - {status["status"]}{"" if no_color else get_color()}')
+                            else:
+                                print(line)
 
-                    print("\n")
+                        print("\n")
 
     if apply:
         print(f'{"" if no_color else get_color("ok_green")}Apply complete!  Resources: {plan["upgrade"]} upgraded, {plan["downgrade"]} downgraded{"" if no_color else get_color()}')
@@ -671,6 +725,13 @@ def run_plan_apply(terraform_files, patterns, target=[], apply=False, verbose=Fa
         print(f'{"" if no_color else get_color("ok_green")}Plan: {plan["upgrade"]} to upgrade, {plan["downgrade"]} to downgrade{"" if no_color else get_color()}')
     else:
         print(f'{"" if no_color else get_color("ok_green")}No changes.  Dependency versions are up-to-date.{"" if no_color else get_color()}')
+
+    if failures >= 1:
+        print(f'\n{get_color("fail")}Warning: {failures} resource(s) failed to return a list of available versions.{get_color()}')
+        if apply:
+            print(f'{get_color("fail")}These resources were not modified during apply.{get_color()}')
+        if not verbose:
+            print(f'{get_color("fail")}For more details, run the command again with the "--verbose" flag.{get_color()}')
 
     return None
 
@@ -713,3 +774,28 @@ def pretty_code(code, spaces=4, indent_symbols = ("{", "[", "("), outdent_symbol
         new_code.append(line_of_code)
 
     return "\n".join(new_code)
+
+def set_environment_variables(var, config_file=".tfmesh.yaml"):
+    """
+    Sets environment variables based on config and command line variables.
+    """
+    # load configuration file variables
+    config_variables = yaml.safe_load(open(config_file))["variables"]
+
+    # collect and clean command line variables
+    command_line_variables = {}
+    for v in var:
+        name, value = re.findall(r'(\S*) *= *(\S*)', v)[0]
+        name = re.sub(r'[^a-zA-Z0-9_]', "", name)
+        command_line_variables[name] = value
+
+    # merge config variables with command line variables
+    variables = dict(list(config_variables.items()) + list(command_line_variables.items()))
+
+    # set environment variables
+    for name, value in variables.items():
+        # set the environment variable
+        name = f"TFMESH_{name.upper()}"
+        os.environ[name] = value
+
+    return variables


### PR DESCRIPTION
Closes #41 

Code was updated to support the output of request error codes and reasons to improve the experience when there are issues with making an API call.  Furthermore, the ability to set variables on the command line, in the config file, and using environment variables was established with the following precedence order:

* command line using the `--var` flag
* config file which can also be set using the `--var` flag or in the file directly
* environment variables which can be set as normal with `export`

I don't love the current state, but it does advance the functionality.  Refactoring can happen at a future date.  Ugh tech debt.