### PR TITLE
Update pipeline to use Terraform Mesh CLI

### DIFF
--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -28,7 +28,7 @@ jobs:
         id: tfmesh
         run: |
           pip install -r requirements.txt
-          pip install --editable ../../.
+          pip install --editable .
           output=$(tfmesh apply)
           output="${output//'%'/'%25'}"
           output="${output//$'\n'/'%0A'}"

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -29,6 +29,7 @@ jobs:
         run: |
           pip install -r requirements.txt
           pip install --editable .
+          tfmesh init --terraform-folder terraform
           output=$(tfmesh apply)
           output="${output//'%'/'%25'}"
           output="${output//$'\n'/'%0A'}"

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -28,7 +28,8 @@ jobs:
         id: tfmesh
         run: |
           pip install -r requirements.txt
-          output=$(python main.py)
+          pip install --editable ../../.
+          output=$(tfmesh apply)
           output="${output//'%'/'%25'}"
           output="${output//$'\n'/'%0A'}"
           output="${output//$'\r'/'%0D'}"

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -30,7 +30,7 @@ jobs:
           pip install -r requirements.txt
           pip install --editable .
           tfmesh init --terraform-folder terraform
-          output=$(tfmesh apply)
+          output=$(tfmesh apply --no-color)
           output="${output//'%'/'%25'}"
           output="${output//$'\n'/'%0A'}"
           output="${output//$'\r'/'%0D'}"

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-    required_version = "1.1.4" # >=1.1.1
+    required_version = "1.1.3" # >=1.1.1
 
     required_providers {
         aws = {

--- a/tfmesh/core.py
+++ b/tfmesh/core.py
@@ -730,11 +730,11 @@ def run_plan_apply(terraform_files, patterns, target=[], apply=False, verbose=Fa
         print(f'{"" if no_color else get_color("ok_green")}No changes.  Dependency versions are up-to-date.{"" if no_color else get_color()}')
 
     if failures >= 1:
-        print(f'\n{get_color("fail")}Warning: {failures} resource(s) failed to return a list of available versions.{get_color()}')
+        print(f'\n{"" if no_color else get_color("fail")}Warning: {failures} resource(s) failed to return a list of available versions.{"" if no_color else get_color()}')
         if apply:
-            print(f'{get_color("fail")}These resources were not modified during apply.{get_color()}')
+            print(f'{"" if no_color else get_color("fail")}These resources were not modified during apply.{"" if no_color else get_color()}')
         if not verbose:
-            print(f'{get_color("fail")}For more details, run the command again with the "--verbose" flag.{get_color()}')
+            print(f'{"" if no_color else get_color("fail")}For more details, run the command again with the "--verbose" flag.{"" if no_color else get_color()}')
 
     return None
 


### PR DESCRIPTION
Updated the pipeline to stop using `main.py` and start using the Terraform Mesh CLI!  `main.py` was deleted and a bug identified based on the working pipeline raising a pull request was fixed where colors were not properly being removed for some output when the `--no-color` flag was passed to `apply` and `plan`.

Closes #39 