### PR TITLE
Feature/cli improvement

### DIFF
--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -26,7 +26,6 @@ jobs:
         run: |
           pip install -r requirements.txt
           pip install --editable .
-          tfmesh init --terraform-folder terraform
           output=$(tfmesh apply --no-color)
           output="${output//'%'/'%25'}"
           output="${output//$'\n'/'%0A'}"
@@ -34,6 +33,7 @@ jobs:
           echo "::set-output name=changelog::$output"
         env:
           TFMESH_GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+          TFMESH_TERRAFORM_FOLDER: terraform
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-    required_version = "1.1.4" # >1.1.3
+    required_version = "1.0.0" # >1.1.3
 
     required_providers {
         aws = {
             source = "hashicorp/aws"
-            version = "3.74.0" # <=3.0.0, >4.0.0
+            version = "3.73.0" # <=3.0.0, >4.0.0
         }
         azurerm = {
             source = "hashicorp/azurerm"

--- a/tfmesh/__init__.py
+++ b/tfmesh/__init__.py
@@ -6,45 +6,57 @@ from tfmesh.core import *
 CONTEXT_SETTINGS = dict(auto_envvar_prefix='TFMESH')
 
 def workspace_options(f):
-    f = click.option("--terraform-folder", default="")(f)
-    f = click.option("--terraform-file-pattern", default="*.tf")(f)
+    f = click.option("--terraform-folder", default="", help="The name of the folder where Terraform files are located (defaults to the current directory).")(f)
+    f = click.option("--terraform-file-pattern", default="*.tf", help="The pattern for matching Terraform files within the directory (defaults to *.tf).")(f)
+    f = click.option("--var", multiple=True, help="One or more variables to be set as environment variables in the format 'some=value'.")(f)
 
     return f
 
 def get_options(f):
     f = click.argument("attribute", required=False)(f)
-    f = click.option("--allowed", is_flag=True)(f)
-    f = click.option("--exclude-prerelease", is_flag=True)(f)
-    f = click.option("--top", type=int, default=None)(f)
-    f = click.option("--var", multiple=True)(f)
-    # f = click.option("--github_token", default=None)(f)
+    f = click.option("--allowed", is_flag=True, help="Returns only allowed versions when used in conjunction with the versions attribute.")(f)
+    f = click.option("--exclude-prerelease", is_flag=True, help="Returns all non-prerelease versions when used in conjunction with the versions attribute.")(f)
+    f = click.option("--top", type=int, default=None, help="Returns the top n number of results when used in conjunction with the versions attribute.")(f)
 
     return f
 
 def set_options(f):
     f = click.argument("value")(f)
     f = click.argument("attribute", required=False)(f)
-    f = click.option("--exclude-prerelease", is_flag=True)(f)
-    f = click.option("--what-if", is_flag=True)(f)
-    f = click.option("--ignore-constraints", is_flag=True)(f)
-    f = click.option("--var", multiple=True)(f)
-    f = click.option("--force", is_flag=True)(f)
+    f = click.option("--exclude-prerelease", is_flag=True, help="Ensures the set version is not a pre-release.")(f)
+    f = click.option("--ignore-constraints", is_flag=True, help="Allows the version to be set to a valid version that does not meet the defined constraint.")(f)
+    f = click.option("--what-if", is_flag=True, help="Allows for a dry run to see what would happen before making changes.")(f)
+    f = click.option("--force", is_flag=True, help="Allows the version to be set to any value without validation.")(f)
 
     return f
 
 def plan_apply_options(f):
-    f = click.option("--target", nargs=2, multiple=True)(f)
-    f = click.option("--exclude-prerelease", is_flag=True)(f)
-    f = click.option("--ignore-constraints", is_flag=True)(f)
-    f = click.option("--no-color", is_flag=True)(f)
-    f = click.option("--verbose", is_flag=True)(f)
-    f = click.option("--var", multiple=True)(f)
+    f = click.option("--target", nargs=2, multiple=True, help="Takes arguments `TYPE` and `NAME` to allow for specific update targets.  For example, `--target provider aws`.  Multiple targets are allowed.")(f)
+    f = click.option("--exclude-prerelease", is_flag=True, help="Ensures the set version is not a pre-release.")(f)
+    f = click.option("--ignore-constraints", is_flag=True, help="Allows the version to be set to a valid version that does not meet the defined constraint.")(f)
+    f = click.option("--no-color", is_flag=True, help="Removes terminal color formatting, primarily for automation purposes.")(f)
+    f = click.option("--verbose", is_flag=True, help="Returns all resources including those with no version changes.")(f)
     
     return f
 
 @click.group("cli", invoke_without_command=True)
 @click.version_option()
 def cli():
+    """
+    \b
+    A mesh is an interlaced structure. A network of interconnected things. 
+    As a verb, it can mean to be locked together or engaged with another. 
+    
+    Terraform Mesh CLI (or tfmesh for short) is an open source tool designed 
+    to make Terraform version management simple and effective.
+
+    It allows you to get details about versioned Terraform resources in your
+    configuration, set values for versions and constraints, and automatically
+    make updates to your code so you are always up-to-date.
+    
+    It supports all Terraform native version constraint operators as well
+    as public and private sources for providers and modules.
+    """
     pass
 
 @cli.group("get")
@@ -60,13 +72,6 @@ def set():
     Sets attributes for a given resource.
     """
     pass
-
-@cli.command(context_settings=CONTEXT_SETTINGS)
-@workspace_options
-@get_options
-def test(terraform_file_pattern, terraform_folder, attribute, allowed, exclude_prerelease, top, github_token):
-    click.echo(terraform_file_pattern)
-    click.echo(attribute)
 
 @get.command(context_settings=CONTEXT_SETTINGS)
 @get_options
@@ -98,7 +103,7 @@ def terraform(terraform_file_pattern, terraform_folder, attribute, allowed, excl
 
 @get.command(context_settings=CONTEXT_SETTINGS)
 @workspace_options
-def providers(terraform_file_pattern, terraform_folder):
+def providers(terraform_file_pattern, terraform_folder, var):
     """
     Lists all tracked providers.
     """
@@ -144,7 +149,7 @@ def provider(terraform_file_pattern, terraform_folder, name, attribute, allowed,
 
 @get.command(context_settings=CONTEXT_SETTINGS)
 @workspace_options
-def modules(terraform_file_pattern, terraform_folder):
+def modules(terraform_file_pattern, terraform_folder, var):
     """
     Lists all tracked modules.
     """


### PR DESCRIPTION
This is a fairly big change that makes some big improvements.  In summary it:

* Removes the `init` command in favor of always either passing variables on the command line or directly as environment variables.  This creates a more consistent experience, eliminates unnecessary complexity, and reduces risk of exposure of sensitive data to repositories without compromising other features.
* Made the `TFMESH_` environment variable prefix globally available.  This means that all cli options now support being set by an environment variable prefixed with the name of the tool improving automation.  This was important as well in order to fully remove the `init` command.
* Made the CLI DRY by creating decorators for `get`, `set`, and `plan_apply` commands.  This means that all attributes for arguments and options can be managed centrally improving readability and maintainability going forward.
* Updated all CLI documentation (CLI and README) to ensure alignment and a better user experience when working with Terraform Mesh.