### PR TITLE
Semantic Version Sorting Bug Fix

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -5,7 +5,7 @@ module "consul" {
 
 module "conventions" {
   source  = "Jsoconno/conventions/azure"
-  version = "0.5.3" # ~>0.4
+  version = "6.0.0" # >=0.5.0
   # insert the 1 required variable here
 }
 

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-    required_version = "1.1.5" # >1.1.3
+    required_version = "1.1.5" # ~>1.0
 
     required_providers {
         aws = {

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -20,7 +20,7 @@ class TestCore(unittest.TestCase):
         Test that semantic version components are returned as a dictionary
         """
         actual = get_semantic_version(version="v1.2.3")
-        expected = (1, 2, 3)
+        expected = (1, 2, 3, 1000000000000000, 3)
 
         self.assertEqual(actual, expected)
 
@@ -64,10 +64,11 @@ class TestCore(unittest.TestCase):
         """
         Test that version comparisons work correctly.
         """
-        a = (1, 5, 0)
-        b = (1, 5, 10)
-        c = (1, 4)
-        d = (1,)
+        # (major, minor, patch, pre-release=1000000000000000, version_length=N)
+        a = (1, 5, 0, 1000000000000000, 3)
+        b = (1, 5, 10, 1000000000000000, 3)
+        c = (1, 4, 0, 1000000000000000, 2)
+        d = (1, 0, 0, 1000000000000000, 1)
 
         result = (
             compare_versions(a, "=", a) and

--- a/tfmesh/core.py
+++ b/tfmesh/core.py
@@ -198,7 +198,7 @@ def set_dependency_attribute(terraform_files, patterns, resource_type, name, att
             )
         elif what_if:
             result = pretty_print(
-                title=f'The {attribute} was would have changed from "{current_value}" to "{new_value}".'
+                title=f'The {attribute} would have changed from "{current_value}" to "{new_value}".'
             )
         elif attribute == "version" and request["status_code"] != 200 and force:
             update_version(
@@ -264,6 +264,15 @@ def get_semantic_version(version):
     try:
         version = re.findall(regex_pattern, version)[0]
         version = tuple([int(component) for component in version if component != ''])
+
+        # This block is used to standardize all version tuples so that
+        # pre-releases are not prioritized above regular releases.
+        version_length = len(version)
+        missing_version_components = 4-version_length
+
+        if 4-len(version) > 0:
+            # Adding the version length at the end is used for pessimistic constraint operator logic.
+            version = version + (0,)*(missing_version_components-1) + (1000000000000000,) + (version_length,)
     except:
         version = None
 
@@ -416,9 +425,10 @@ def compare_versions(a, op, b):
 
     if a and b:
         if op == "~>":
-            if len(b) == 2:
+            version_length = b[-1]
+            if version_length == 2:
                 result = ops[">="](a, b) and ops["<"](a, (b[0]+1, 0, 0))
-            elif len(b) == 3:
+            elif version_length == 3:
                 result = ops[">="](a, b) and ops["<"](a, (b[0], b[1]+1, 0))
             else:
                 raise ValueError("When using a pessimistic version constraint, the version value must only have two or three parts (e.g. 1.0, 1.1.0).")


### PR DESCRIPTION
Updated semantic versioning and sorting so that regular releases take precedent over pre-releases.

Closes #36 